### PR TITLE
DRUPAL9: Fix Drupal 9 incompatible code

### DIFF
--- a/og_sm_admin_menu/css/site_switcher.css
+++ b/og_sm_admin_menu/css/site_switcher.css
@@ -1,7 +1,9 @@
 /**
  * Custom styling for the Administration menu.
  */
-.toolbar .toolbar-site-switcher {
+.toolbar .toolbar-site-switcher,
+.adminimal-admin-toolbar .toolbar .toolbar-bar .toolbar-tab > .toolbar-site-switcher.is-active,
+.adminimal-admin-toolbar .toolbar .toolbar-bar .toolbar-tab > .toolbar-site-switcher:focus {
   background: #ff9933;
   background-image: none !important;
   color: #000 !important;

--- a/og_sm_admin_menu/og_sm_admin_menu.module
+++ b/og_sm_admin_menu/og_sm_admin_menu.module
@@ -8,7 +8,7 @@
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\og_sm\OgSm;
-use Drupal\og_sm_admin_menu\Render\Element\AdminToolbar;
+use Drupal\og_sm_admin_menu\Render\Element\SiteManagerAdminToolbar;
 
 /**
  * Implements hook_local_tasks_alter().
@@ -129,7 +129,7 @@ function og_sm_admin_menu_toolbar() {
  */
 function og_sm_admin_menu_toolbar_alter(&$items) {
   $items['administration']['tray']['toolbar_administration']['#pre_render'] = [
-    [AdminToolbar::class, 'preRenderTray'],
+    [SiteManagerAdminToolbar::class, 'preRenderTray'],
   ];
   $items['administration']['#cache']['contexts'][] = 'og_group_context';
 }

--- a/og_sm_admin_menu/og_sm_admin_menu.module
+++ b/og_sm_admin_menu/og_sm_admin_menu.module
@@ -5,12 +5,10 @@
  * Site Manager Administration module.
  */
 
-use Drupal\admin_toolbar\Render\Element\AdminToolbar;
 use Drupal\Core\Template\Attribute;
-use Drupal\og_sm\OgSm;
-use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\Url;
-use Drupal\toolbar\Controller\ToolbarController;
+use Drupal\og_sm\OgSm;
+use Drupal\og_sm_admin_menu\Render\Element\AdminToolbar;
 
 /**
  * Implements hook_local_tasks_alter().
@@ -130,48 +128,10 @@ function og_sm_admin_menu_toolbar() {
  * Implements hook_toolbar_alter().
  */
 function og_sm_admin_menu_toolbar_alter(&$items) {
-  $items['administration']['tray']['toolbar_administration']['#pre_render'] = ['og_sm_admin_menu_prerender_toolbar_administration_tray'];
-  $items['administration']['#cache']['contexts'][] = 'og_group_context';
-}
-
-/**
- * Renders the toolbar's site administration tray.
- *
- * @param array $element
- *   A renderable array.
- *
- * @return array
- *   The updated renderable array.
- */
-function og_sm_admin_menu_prerender_toolbar_administration_tray(array $element) {
-  $site_manager = OgSm::siteManager();
-
-  $admin_toolbar_exists = \Drupal::moduleHandler()->moduleExists('admin_toolbar');
-
-  if (!$site_manager->currentSite()) {
-    // If there's no site context, render the toolbar as usual.
-    return $admin_toolbar_exists ? AdminToolbar::preRenderTray($element) : ToolbarController::preRenderAdministrationTray($element);
-  }
-
-  // @todo This can be simplified once https://www.drupal.org/node/1869638 has
-  // been implemented in core and the "admin_toolbar" module.
-  /** @var \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree */
-  $menu_tree = \Drupal::service('toolbar.menu_tree');
-  $parameters = new MenuTreeParameters();
-  // Depending on whether the 'admin_toolbar' module exists we should change the
-  // menu depth shown in the toolbar.
-  $max_depth = $admin_toolbar_exists ? 4 : 2;
-  $parameters->setMinDepth(2)->setMaxDepth($max_depth)->onlyEnabledLinks();
-  $tree = $menu_tree->load('og_sm_admin_menu', $parameters);
-  $manipulators = [
-    ['callable' => 'menu.default_tree_manipulators:checkAccess'],
-    ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-    ['callable' => $admin_toolbar_exists ? 'toolbar_tools_menu_navigation_links' : 'toolbar_menu_navigation_links'],
+  $items['administration']['tray']['toolbar_administration']['#pre_render'] = [
+    [AdminToolbar::class, 'preRenderTray'],
   ];
-  $tree = $menu_tree->transform($tree, $manipulators);
-  $element['administration_menu'] = $menu_tree->build($tree);
-
-  return $element;
+  $items['administration']['#cache']['contexts'][] = 'og_group_context';
 }
 
 /**

--- a/og_sm_admin_menu/src/Render/Element/AdminToolbar.php
+++ b/og_sm_admin_menu/src/Render/Element/AdminToolbar.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\og_sm_admin_menu\Render\Element;
+
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\og_sm\OgSm;
+use Drupal\og_sm_admin_menu\Controller\ToolbarController;
+
+/**
+ * Pre render callbacks for the AdminToolbar.
+ */
+class AdminToolbar implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRenderTray'];
+  }
+
+  /**
+   * Pre render the admin tray.
+   *
+   * @param array $build
+   *   The build to alter.
+   *
+   * @return array
+   *   Tha altered render array.
+   */
+  public static function preRenderTray(array $build): array {
+    $site_manager = OgSm::siteManager();
+
+    $admin_toolbar_exists = \Drupal::moduleHandler()->moduleExists('admin_toolbar');
+
+    if (!$site_manager->currentSite()) {
+      // If there's no site context, render the toolbar as usual.
+      return $admin_toolbar_exists
+        ? AdminToolbar::preRenderTray($build)
+        : ToolbarController::preRenderAdministrationTray($build);
+    }
+
+    // @todo This can be simplified once https://www.drupal.org/node/1869638 has
+    // been implemented in core and the "admin_toolbar" module.
+    /** @var \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree */
+    $menu_tree = \Drupal::service('toolbar.menu_tree');
+    $parameters = new MenuTreeParameters();
+    // Depending on whether the 'admin_toolbar' module exists we should change
+    // the menu depth shown in the toolbar.
+    $max_depth = $admin_toolbar_exists ? 4 : 2;
+    $parameters->setMinDepth(2)->setMaxDepth($max_depth)->onlyEnabledLinks();
+    $tree = $menu_tree->load('og_sm_admin_menu', $parameters);
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+      ['callable' => $admin_toolbar_exists ? 'toolbar_tools_menu_navigation_links' : 'toolbar_menu_navigation_links'],
+    ];
+    $tree = $menu_tree->transform($tree, $manipulators);
+    $build['administration_menu'] = $menu_tree->build($tree);
+
+    return $build;
+  }
+
+}

--- a/og_sm_admin_menu/src/Render/Element/SiteManagerAdminToolbar.php
+++ b/og_sm_admin_menu/src/Render/Element/SiteManagerAdminToolbar.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\og_sm_admin_menu\Render\Element;
 
+use Drupal\admin_toolbar\Render\Element\AdminToolbar;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\Security\TrustedCallbackInterface;
 use Drupal\og_sm\OgSm;
@@ -12,7 +13,7 @@ use Drupal\og_sm_admin_menu\Controller\ToolbarController;
 /**
  * Pre render callbacks for the AdminToolbar.
  */
-class AdminToolbar implements TrustedCallbackInterface {
+class SiteManagerAdminToolbar implements TrustedCallbackInterface {
 
   /**
    * {@inheritdoc}
@@ -28,37 +29,37 @@ class AdminToolbar implements TrustedCallbackInterface {
    *   The build to alter.
    *
    * @return array
-   *   Tha altered render array.
+   *   The altered render array.
    */
   public static function preRenderTray(array $build): array {
-    $site_manager = OgSm::siteManager();
+    $siteManager = OgSm::siteManager();
 
-    $admin_toolbar_exists = \Drupal::moduleHandler()->moduleExists('admin_toolbar');
+    $adminToolbarExists = \Drupal::moduleHandler()->moduleExists('admin_toolbar');
 
-    if (!$site_manager->currentSite()) {
+    if (!$siteManager->currentSite()) {
       // If there's no site context, render the toolbar as usual.
-      return $admin_toolbar_exists
+      return $adminToolbarExists
         ? AdminToolbar::preRenderTray($build)
         : ToolbarController::preRenderAdministrationTray($build);
     }
 
     // @todo This can be simplified once https://www.drupal.org/node/1869638 has
     // been implemented in core and the "admin_toolbar" module.
-    /** @var \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree */
-    $menu_tree = \Drupal::service('toolbar.menu_tree');
+    /** @var \Drupal\Core\Menu\MenuLinkTreeInterface $menuTree */
+    $menuTree = \Drupal::service('toolbar.menu_tree');
     $parameters = new MenuTreeParameters();
     // Depending on whether the 'admin_toolbar' module exists we should change
     // the menu depth shown in the toolbar.
-    $max_depth = $admin_toolbar_exists ? 4 : 2;
+    $max_depth = $adminToolbarExists ? 4 : 2;
     $parameters->setMinDepth(2)->setMaxDepth($max_depth)->onlyEnabledLinks();
-    $tree = $menu_tree->load('og_sm_admin_menu', $parameters);
+    $tree = $menuTree->load('og_sm_admin_menu', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
-      ['callable' => $admin_toolbar_exists ? 'toolbar_tools_menu_navigation_links' : 'toolbar_menu_navigation_links'],
+      ['callable' => $adminToolbarExists ? 'toolbar_tools_menu_navigation_links' : 'toolbar_menu_navigation_links'],
     ];
-    $tree = $menu_tree->transform($tree, $manipulators);
-    $build['administration_menu'] = $menu_tree->build($tree);
+    $tree = $menuTree->transform($tree, $manipulators);
+    $build['administration_menu'] = $menuTree->build($tree);
 
     return $build;
   }

--- a/og_sm_content/og_sm_content.routing.yml
+++ b/og_sm_content/og_sm_content.routing.yml
@@ -41,8 +41,8 @@ og_sm.site_content.add_page:
 og_sm.site_content.add:
   path: '/group/node/{node}/content/add/{node_type}'
   defaults:
-    _controller: '\Drupal\node\Controller\NodeController::add'
     _title_callback: '\Drupal\node\Controller\NodeController::addPageTitle'
+    _controller: '\Drupal\og_sm_content\Controller\SiteContentController::add'
   requirements:
     _og_sm_site_content_add_access: 'node:{node_type}'
   options:
@@ -51,4 +51,5 @@ og_sm.site_content.add:
       node:
         type: og_sm:site
       node_type:
+        type: entity:node_type
         with_config_overrides: TRUE

--- a/og_sm_content/src/Controller/SiteContentController.php
+++ b/og_sm_content/src/Controller/SiteContentController.php
@@ -118,8 +118,6 @@ class SiteContentController extends ControllerBase {
   /**
    * Provides the node submission form.
    *
-   * @param \Drupal\node\NodeInterface $node
-   *   The site to create the node for.
    * @param \Drupal\node\NodeTypeInterface $node_type
    *   The node type entity for the node.
    *

--- a/og_sm_content/src/Controller/SiteContentController.php
+++ b/og_sm_content/src/Controller/SiteContentController.php
@@ -6,6 +6,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\node\NodeInterface;
+use Drupal\node\NodeTypeInterface;
 use Drupal\og\OgAccessInterface;
 use Drupal\og_sm\SiteTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -112,6 +113,25 @@ class SiteContentController extends ControllerBase {
     $build['#content'] = $content;
 
     return $build;
+  }
+
+  /**
+   * Provides the node submission form.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The site to create the node for.
+   * @param \Drupal\node\NodeTypeInterface $node_type
+   *   The node type entity for the node.
+   *
+   * @return array
+   *   A node submission form.
+   */
+  public function add(NodeTypeInterface $node_type): array {
+    $node = $this->entityTypeManager()->getStorage('node')->create([
+      'type' => $node_type->id(),
+    ]);
+
+    return $this->entityFormBuilder()->getForm($node);
   }
 
 }


### PR DESCRIPTION
* Fix deprecated pre_render usage.
* Fix route to add site content.
* Fix toolbar Site switcher tab color.